### PR TITLE
Enable hardware acceleration

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,7 +7,7 @@
 
     <uses-sdk
         android:minSdkVersion="10"
-        android:targetSdkVersion="10" />
+        android:targetSdkVersion="11" />
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -22,6 +22,7 @@
         <activity
             android:name=".Kaleidoscope"
             android:label="@string/app_name"
+            android:hardwareAccelerated="true"
             android:launchMode="singleTop" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/res/drawable/shape_menu.xml
+++ b/res/drawable/shape_menu.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <solid android:color="#000" />

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -45,5 +45,8 @@
     <string name="disable_camera_title">Camera in menu</string>
     <string name="disable_camera_summary1">Camera is present in menu</string>
     <string name="disable_camera_summary2">Camera is removed from menu</string>
+    <string name="hardware_accel_title">Hardware acceleration</string>
+    <string name="hardware_accel_summary">Requires Android +3.0</string>
+    <string name="hardware_accel_toast">Restart required</string>
     
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -49,6 +49,12 @@
     <PreferenceCategory android:title="@string/kps_cat" >
         <CheckBoxPreference
             android:defaultValue="true"
+            android:key="hardware_accel"
+            android:title="@string/hardware_accel_title"
+            android:summary="@string/hardware_accel_summary" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:key="camera_in_menu"
             android:summaryOff="@string/disable_camera_summary2"
             android:summaryOn="@string/disable_camera_summary1"

--- a/src/vnd/blueararat/kaleidoscope6/Kaleidoscope.java
+++ b/src/vnd/blueararat/kaleidoscope6/Kaleidoscope.java
@@ -20,6 +20,7 @@ import android.hardware.SensorManager;
 import android.net.Uri;
 import android.opengl.GLSurfaceView;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
@@ -36,6 +37,7 @@ public class Kaleidoscope extends Activity {
 	SharedPreferences preferences;
 	static final String KEY_IMAGE_URI = "image_uri";
 	static final String KEY_CAMERA_IN_MENU = "camera_in_menu";
+	static final String KEY_HARDWARE_ACCEL = "hardware_accel";
 	// private static final String TAG = "Kaleidoscope";
 	static final int CHANGE_NUMBER_OF_MIRRORS = 1;
 	private static final int OPEN_PICTURE = 2;
@@ -63,6 +65,7 @@ public class Kaleidoscope extends Activity {
 		preferences = PreferenceManager.getDefaultSharedPreferences(this);
 		sStringUri = preferences.getString(KEY_IMAGE_URI, "");
 		bCameraInMenu = preferences.getBoolean(KEY_CAMERA_IN_MENU, true);
+
 		Options options = new BitmapFactory.Options();
 		options.inScaled = false;
 		if (sStringUri.length() != 0) {
@@ -84,6 +87,9 @@ public class Kaleidoscope extends Activity {
 		mFrame = (FrameLayout) findViewById(R.id.frame);
 
 		mFrame.addView(mK);
+
+		toggleHardwareAcceleration(preferences.getBoolean(KEY_HARDWARE_ACCEL, true));
+
 		// setContentView(mK);
 	}
 
@@ -313,6 +319,7 @@ public class Kaleidoscope extends Activity {
 		case R.id.K3D:
 			toggle3D(use3D = !use3D);
 			return true;
+
 		}
 
 		return false;
@@ -366,6 +373,7 @@ public class Kaleidoscope extends Activity {
 	@Override
 	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 		super.onActivityResult(requestCode, resultCode, data);
+
 
 		if (requestCode == OPEN_PICTURE) {
 			if (resultCode == RESULT_OK) {
@@ -432,5 +440,17 @@ public class Kaleidoscope extends Activity {
 				.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
 		cursor.moveToFirst();
 		return cursor.getString(column_index);
+	}
+
+	private void toggleHardwareAcceleration(boolean requestEnabled) {
+
+		if (Build.VERSION.SDK_INT < 11)
+			return;
+
+		if (!requestEnabled) {
+			// Are there other views that can be set?
+			mOverlayView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+			mK.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+		}
 	}
 }

--- a/src/vnd/blueararat/kaleidoscope6/Prefs.java
+++ b/src/vnd/blueararat/kaleidoscope6/Prefs.java
@@ -13,6 +13,7 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.view.View;
+import android.widget.Toast;
 
 public class Prefs extends PreferenceActivity implements
 		OnSharedPreferenceChangeListener {
@@ -25,6 +26,7 @@ public class Prefs extends PreferenceActivity implements
 	private SeekbarPref mSeekbarPrefB;
 	private CheckBoxPreference mCheckBoxBlur;
 	private CheckBoxPreference mCheckBoxCameraInMenu;
+	private CheckBoxPreference mCheckBoxHardwareAccel;
 	private FolderPref mPrefSaveLocation;
 	private String mDefaultSaveLocation;
 
@@ -42,6 +44,8 @@ public class Prefs extends PreferenceActivity implements
 				.findPreference("blur");
 		mCheckBoxCameraInMenu = (CheckBoxPreference) getPreferenceScreen()
 				.findPreference(Kaleidoscope.KEY_CAMERA_IN_MENU);
+		mCheckBoxHardwareAccel = (CheckBoxPreference) getPreferenceScreen()
+				.findPreference(Kaleidoscope.KEY_HARDWARE_ACCEL);
 		mSaveFormat = (ListPreference) getPreferenceScreen().findPreference(
 				"format");
 		mSaveFormat.setSummary(getString(R.string.pictures_will_be_saved) + " "
@@ -64,6 +68,18 @@ public class Prefs extends PreferenceActivity implements
 						return true;
 					}
 				});
+
+		mCheckBoxHardwareAccel.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+			@Override
+			public boolean onPreferenceClick(Preference preference) {
+				Toast.makeText(getApplicationContext(),
+						R.string.hardware_accel_toast,
+						Toast.LENGTH_LONG).show();
+				return true;
+			}
+		});
+
+
 	}
 
 	@Override
@@ -109,6 +125,17 @@ public class Prefs extends PreferenceActivity implements
 		}
 	}
 
+	// Save all preferences before exiting.
+	// Since the hardware accel switch prompts for restart, it is better UX
+	// to have it save automaticalli since they may close the app after toggling
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
+		SharedPreferences preferences = PreferenceManager
+				.getDefaultSharedPreferences(this);
+		preferences.edit().commit();
+	}
+
 	public void onButtonClicked(View v) {
 		SharedPreferences preferences = PreferenceManager
 				.getDefaultSharedPreferences(this);
@@ -122,6 +149,7 @@ public class Prefs extends PreferenceActivity implements
 		mSeekbarPrefB.setProgressValue(49);
 		mCheckBoxBlur.setChecked(true);
 		mCheckBoxCameraInMenu.setChecked(true);
+		mCheckBoxHardwareAccel.setChecked(true);
 		mPrefSaveLocation.reset();
 	}
 


### PR DESCRIPTION
This commit bumps the minimum SDK requirement from 10 to 11 in order to
enable hardware acceleration by default. A preference has been added to
disable/enable the feature, however it is on by default. Devices that
are below SDK version 11 are not affected.

Summary of changes:
- Bump minimum SDK version from 10 to 11
- Added a toast prompting to restart when checking/unchecking the
  hardware acceleration preference
- All preferences are now saved when the preferences activity is
  destroyed
- New strings were added for the preference
